### PR TITLE
[A.Y. 2024/2025 Beckmann, Amadeus] Exercise: Available

### DIFF
--- a/dpongpy/__init__.py
+++ b/dpongpy/__init__.py
@@ -66,6 +66,8 @@ class PongGame:
             self.dt = 0
             self.before_run()
             while self.running:
+                self.pong.interpolate_state()
+
                 self.controller.handle_inputs(self.dt)
                 self.controller.handle_events()
                 self.view.render()

--- a/dpongpy/model.py
+++ b/dpongpy/model.py
@@ -481,6 +481,19 @@ class Pong(Sized):
     def stop_paddle(self, paddle: int | Direction):
         self.move_paddle(paddle, Direction.NONE)
 
+    def interpolate_state(self):
+        if self.last_server_time is None or self.current_server_time is None:
+            # We don't have enough data to interpolate yet
+            return
+
+        delta_time = self.local_time - self.last_update_time
+        server_interval = self.current_server_time - self.last_server_time
+        progress = min(delta_time / server_interval, 1.0)
+
+        self.ball.interpolate_towards_server_state(progress)
+        for paddle in self.paddles:
+            paddle.interpolate_towards_server_state(progress)
+
     def override(self, other: 'Pong', update_server_state=False):
         if self is other:
             return

--- a/dpongpy/model.py
+++ b/dpongpy/model.py
@@ -165,6 +165,9 @@ class GameObject(Sized, Positioned):
         self._size = Vector2(size)
         self._position = Vector2(position) if position is not None else Vector2()
         self._speed = Vector2(speed) if speed is not None else Vector2()
+        self._server_size = None
+        self._server_position = None
+        self._server_speed = None
         self.name = name or self.__class__.__name__.lower()
 
     def __eq__(self, other):
@@ -229,6 +232,20 @@ class GameObject(Sized, Positioned):
         self.size = other.size
         self.position = other.position
         self.speed = other.speed
+
+    def update_server_state(self, other: 'GameObject'):
+        assert isinstance(other, type(self)) and other.name == self.name, f"Invalid override: {other} -> {self}"
+        self._server_size = other.size
+        self._server_position = other.position
+        self._server_speed = other.speed
+
+    def interpolate_towards_server_state(self, progress):
+        if self._server_size is not None:
+            self.size = self.size.lerp(self._server_size, progress)
+        if self._server_position is not None:
+            self.position = self.position.lerp(self._server_position, progress)
+        if self._server_speed is not None:
+            self.speed = self.speed.lerp(self._server_speed, progress)
 
 
 for method_name in ['overlaps', 'is_inside', '__contains__', 'intersection_with', 'hits']:

--- a/dpongpy/model.py
+++ b/dpongpy/model.py
@@ -465,13 +465,16 @@ class Pong(Sized):
     def stop_paddle(self, paddle: int | Direction):
         self.move_paddle(paddle, Direction.NONE)
 
-    def override(self, other: 'Pong'):
+    def override(self, other: 'Pong', update_server_state=False):
         if self is other:
             return
         logger.debug(f"Overriding Pong status")
         self.size = other.size
         self.config = other.config
-        self.ball.override(other.ball)
+        if update_server_state:
+            self.ball.update_server_state(other.ball)
+        else:
+            self.ball.override(other.ball)
         self.board = other.board
         self.updates = other.updates
         self.time = other.time
@@ -488,5 +491,8 @@ class Pong(Sized):
         for side, paddle in removed.items():
             self.remove_paddle(side)
         for side, paddle in common.items():
-            self.paddle(side).override(other.paddle(side))
+            if update_server_state:
+                self.paddle(side).update_server_state(other.paddle(side))
+            else:
+                self.paddle(side).override(other.paddle(side))
         return added, removed

--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -127,9 +127,6 @@ class PongTerminal(PongGame):
                     terminal._events_queue.put(event)
                 return event
 
-            def handle_inputs(self, dt=None):
-                return super().handle_inputs(dt)
-
             def on_paddle_move(self, pong: Pong, paddle_index: Direction, direction: Direction):
                 pong.move_paddle(paddle_index, direction)
 

--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -124,10 +124,16 @@ class PongTerminal(PongGame):
                 return event
 
             def handle_inputs(self, dt=None):
-                return super().handle_inputs(dt=None) # just handle input events, do not handle time elapsed
-            
-            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong): # type: ignore[override]
-                pong.override(status)
+                return super().handle_inputs(dt)
+
+            def on_paddle_move(self, pong: Pong, paddle_index: Direction, direction: Direction):
+                pong.move_paddle(paddle_index, direction)
+
+            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong = None): # type: ignore[override]
+                if status is None:
+                    pong.update(dt)
+                else:
+                    pong.override(status, update_server_state=True)
 
             def on_player_leave(self, pong: Pong, paddle_index: Direction):
                 terminal.stop()

--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -137,9 +137,9 @@ class PongTerminal(PongGame):
 
             def on_player_leave(self, pong: Pong, paddle_index: Direction):
                 terminal.stop()
-        
+
         return Controller(terminal.pong, paddle_commands)
-    
+
     def _handle_ingoing_messages(self):
         while self.running:
             message = self.client.receive()

--- a/justfile
+++ b/justfile
@@ -11,4 +11,4 @@ client1:
     poetry run dpongpy -m centralised -r terminal --side left --keys wasd --host 127.0.0.1
 
 client2:
-    poetry run dpongpy -m centralised -r terminal --side right --keys arrows --host 127.0.0.1
+    poetry run dpongpy -m centralised -r terminal --side right --keys wasd --host 127.0.0.1

--- a/justfile
+++ b/justfile
@@ -1,0 +1,11 @@
+# Uncomment the following line to enable packet dropping
+#export UDP_DROP_RATE := "0.2"
+
+server:
+    poetry run dpongpy -m centralised -r coordinator
+
+client1:
+    poetry run dpongpy -m centralised -r terminal --side left --keys wasd --host 127.0.0.1
+
+client2:
+    poetry run dpongpy -m centralised -r terminal --side right --keys arrows --host 127.0.0.1

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 # Uncomment the following line to enable packet dropping
 #export UDP_DROP_RATE := "0.2"
 
+local:
+    poetry run dpongpy -m local --side left --keys wasd --side right --keys arrows
+
 server:
     poetry run dpongpy -m centralised -r coordinator -f 30
 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 #export UDP_DROP_RATE := "0.2"
 
 server:
-    poetry run dpongpy -m centralised -r coordinator
+    poetry run dpongpy -m centralised -r coordinator -f 30
 
 client1:
     poetry run dpongpy -m centralised -r terminal --side left --keys wasd --host 127.0.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ mypy = "mypy dpongpy tests"
 compile = "python -m compileall dpongpy tests"
 
 [tool.poetry.scripts]
-dpongpy = "dpongpy:main"
+dpongpy = "dpongpy.__main__:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.python3
+    pkgs.poetry
+  ];
+}
+

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,7 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.python3
     pkgs.poetry
+    pkgs.just
   ];
 }
 

--- a/shell.nix
+++ b/shell.nix
@@ -7,4 +7,3 @@ pkgs.mkShell {
     pkgs.just
   ];
 }
-


### PR DESCRIPTION
### Description
The changes in the PR implement the speculative execution pattern from the lecture for the *terminal*. This makes the terminal to run much smoother and responsive even when the communication with the coordinator is inconsistent (e.g. through dropped packets).

### Portability
To improve portability, I first added a [Nix shell](https://nixos.wiki/wiki/Development_environment_with_nix-shell) configuration that installs Python, Poetry, and [`just`](https://github.com/casey/just). This allows us to create reproducible environments on other computers to make it easier to run **Distributed Pong**. I also added some `just` commands (`just server`, `just client1`, and `just client2`) to make starting the server and clients easier.

### Non-blocking game loop
Following the exercise hints, I introduced two background threads to the terminal: one for receiving server messages, and one for sending commands to the server. Receiving messages from a thread is done in the same way as it is done for the server, however, sending commands from a thread requires a queue into which we write events and from which the thread reads events to dispatch them via UDP. Both threads run while the game is *running*.

### Speculative updates
Additionally, I modified the `PongTerminal.Controller` class so that it also dispatches a `TIME_ELAPSED` event locally. This was done by simple removing the `handle_inputs` method entirely. Furthermore, I added a method `on_paddle_move` to handle the `PADDLE_MOVE` event. This lets the user control their paddle locally whenever they push the according buttons on their keyboard. Finally, we have to run `pong.update(dt)` in the `on_time_elapsed` handler to compute collisions and update positions locally. This handler is already used to override the game state when the according server message was received, however, the `pong` parameter is `None` when the event was dispatched locally. This lets us decide whether we want to perform the update step or instead apply the server state.

### Server state in `GameObjects`
Now, that we're tinkering with the game state locally, we have to introduce proper interpolation of the server state to prevent objects from jumping around. This interpolation requires the introduction of server state variables for size, position, and speed in the `GameObject` model. The server is our single source of truth, but the local, speculative values are used in the terminal to render the game. So instead of applying the server state immediately which would cause erratic rendering, we only save these values and interpolate towards them during rendering. This all can be done by two new methods `update_server_state` and `interpolate_towards_server_state`, which set the server state of a `GameObject` and adjust the local state towards the server state respectively.

### Interpolation step
Finally, I added an extra interpolation step to the game main loop. In this step, we first compute an adaptive scalar which is used to linearly interpolate between the local state and the server state. This adaptive scalar is calculated based on the ratio of the time since the last rendering and the time since the last server update. This ensures a smooth interpolation, even when some packets get lost along the way. In this way, a packet loss of 20% (server to client) or less is hardly noticeable. Even with 50% packet loss (server to client), the game remains playable.

### Running Available Distributed Pong
To run this **Available** version of **Distributed Pong**, you have to first start a server:
```bash
# Start the Pong server
# For the server, the FPS effectively control the tick rate at which packets are sent to the clients
# This tick rate is set to 30 here, however, anything >= 20 worked fine in my tests
poetry run dpongpy -m centralised -r coordinator -f 30
```

Then, you can run two clients:
```bash
poetry run dpongpy -m centralised -r terminal --side left --keys wasd --host 127.0.0.1
poetry run dpongpy -m centralised -r terminal --side right --keys wasd --host 127.0.0.1
```