### PR TITLE
[A.Y. 2024/2025 Monaldini, Nicolò] Exercise: Available Distributed Pong

### DIFF
--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -107,6 +107,8 @@ class PongTerminal(PongGame):
         super().__init__(settings)
         self.pong.reset_ball(Vector2(0))
         self.client = UdpClient(Address(self.settings.host or DEFAULT_HOST, self.settings.port or DEFAULT_PORT))
+        self._thread_receiver = threading.Thread(target=self._handle_ingoing_messages, daemon=True)
+        self._thread_receiver.start()
 
     def create_controller(terminal, paddle_commands = None):
         from dpongpy.controller.local import PongInputHandler, EventHandler
@@ -120,24 +122,23 @@ class PongTerminal(PongGame):
                 if not ControlEvent.TIME_ELAPSED.matches(event):
                     terminal.client.send(serialize(event))
                 return event
-
-            def handle_inputs(self, dt=None):
-                return super().handle_inputs(dt=None) # just handle input events, do not handle time elapsed
             
-            def handle_events(self):
-                terminal._handle_ingoing_messages()
-                super().handle_events()
-            
-            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong): # type: ignore[override]
-                pong.override(status)
+            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong = None): # type: ignore[override]
+                if not status:
+                    pong.update(dt)
+                else:
+                    pong.override(status)
 
+            def on_paddle_move(self, pong: Pong, paddle_index: Direction, direction: Direction):
+                pong.move_paddle(paddle_index, direction)
+            
             def on_player_leave(self, pong: Pong, paddle_index: Direction):
                 terminal.stop()
         
         return Controller(terminal.pong, paddle_commands)
     
     def _handle_ingoing_messages(self):
-        if self.running:
+        while self.running:
             message = self.client.receive()
             message = deserialize(message)
             assert isinstance(message, pygame.event.Event), f"Expected {pygame.event.Event}, got {type(message)}"


### PR DESCRIPTION
# Description
To implement speculative execution the reception of messages from the server had to first be made non-blocking on the client side. To achieve this, a separate thread for the execution of _handle_ingoing_messages function was created. The main thread doesn't have to manage the reception of messages anymore (i.e. executing _handle_ingoing_messages when handling events), therefore the override of the handle_events function was removed.

To allow the update of the model on the client side in case of network issues, the management of events had to be slightly changed: instead of only communicating user input to the server and waiting for its response to update the local model, the client updates its model based on its own inputs, and every time it receives a message from the server the local model is overwritten. In particular, the updates the client performs on its own are related to its paddle's movement and time passing; for this reason, on_paddle_move function was overridden, handle_inputs was modified to produce time_elapsed events and on_time_elapsed was overriden to perform the whole model overwrite only when the time_elapsed events are produced from the server.
