### PR TITLE
[A.Y. 2024/2025 Pracucci, Filippo] Exercise: Available Distributed Pong

### DIFF
--- a/dpongpy/remote/centralised/README.md
+++ b/dpongpy/remote/centralised/README.md
@@ -1,0 +1,23 @@
+# Exercise: Available Distributed Pong
+
+The implementation has been modified to prioritize availability over consistency, in order to make the game more fluid for the user.
+
+To achieve the goal, it has been implemented the speculative execution on the terminal-side. In particular, the terminal's game-loop should not block while waiting for updates from the coordinator, so the handling of receiving events is given to a separate thread.
+
+The terminal updates his local game state according to the local input received, so it has to overwrite the local game state with the remote one only in case of an update provided by the coordinator.
+
+## Testing
+
+In order to test the implementation, it's necessary to execute a coordinator and at least two terminals:
+
+- to execute the coordinator:
+    ```
+    python -m dpongpy --mode centralised --role coordinator
+    ```
+
+- to execute the terminals:
+    ```
+    python -m dpongpy --mode centralised --role terminal --side {left,up,right,down} --keys {wasd,arrows,ijkl,numpad}
+    ```
+
+It's also possible to specify the host and the port of the coordinator, so accordingly in the terminal execution's command.

--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -107,6 +107,8 @@ class PongTerminal(PongGame):
         super().__init__(settings)
         self.pong.reset_ball(Vector2(0))
         self.client = UdpClient(Address(self.settings.host or DEFAULT_HOST, self.settings.port or DEFAULT_PORT))
+        self._thread_receiver = threading.Thread(target=self._handle_ingoing_messages, daemon=True)
+        self._thread_receiver.start()
 
     def create_controller(terminal, paddle_commands = None):
         from dpongpy.controller.local import PongInputHandler, EventHandler
@@ -122,14 +124,19 @@ class PongTerminal(PongGame):
                 return event
 
             def handle_inputs(self, dt=None):
-                return super().handle_inputs(dt=None) # just handle input events, do not handle time elapsed
-            
+                return super().handle_inputs(dt)
+
             def handle_events(self):
-                terminal._handle_ingoing_messages()
-                super().handle_events()
+                return super().handle_events()
+
+            def on_paddle_move(self, pong, paddle_index, direction):
+                pong.move_paddle(paddle_index, direction)
             
-            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong): # type: ignore[override]
-                pong.override(status)
+            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong = None): # type: ignore[override]
+                if not status:
+                    pong.update(dt)
+                else:
+                    pong.override(status)
 
             def on_player_leave(self, pong: Pong, paddle_index: Direction):
                 terminal.stop()
@@ -137,7 +144,7 @@ class PongTerminal(PongGame):
         return Controller(terminal.pong, paddle_commands)
     
     def _handle_ingoing_messages(self):
-        if self.running:
+        while self.running:
             message = self.client.receive()
             message = deserialize(message)
             assert isinstance(message, pygame.event.Event), f"Expected {pygame.event.Event}, got {type(message)}"


### PR DESCRIPTION
# Exercise: Available Distributed Pong

The implementation has been modified to prioritize availability over consistency, in order to make the game more fluid for the user.

To achieve the goal, it has been implemented the speculative execution on the terminal-side. In particular, the terminal's game-loop should not block while waiting for updates from the coordinator, so the handling of receiving events is given to a separate thread.

The terminal updates his local game state according to the local input received, so it has to overwrite the local game state with the remote one only in case of an update provided by the coordinator.

## Testing

In order to test the implementation, it's necessary to execute a coordinator and at least two terminals:

- to execute the coordinator:
    ```
    python -m dpongpy --mode centralised --role coordinator
    ```

- to execute the terminals:
    ```
    python -m dpongpy --mode centralised --role terminal --side {left,up,right,down} --keys {wasd,arrows,ijkl,numpad}
    ```

It's also possible to specify the host and the port of the coordinator, so accordingly in the terminal execution's command.
