### PR TITLE
[A.Y. 2024/2025 Morelli, Marco] Exercise: Available Distributed Pong

### DIFF
--- a/dpongpy/remote/centralised/__init__.py
+++ b/dpongpy/remote/centralised/__init__.py
@@ -107,6 +107,8 @@ class PongTerminal(PongGame):
         super().__init__(settings)
         self.pong.reset_ball(Vector2(0))
         self.client = UdpClient(Address(self.settings.host or DEFAULT_HOST, self.settings.port or DEFAULT_PORT))
+        self._thread_receiver = threading.Thread(target=self._handle_ingoing_messages, daemon=True)
+        self._thread_receiver.start()
 
     def create_controller(terminal, paddle_commands = None):
         from dpongpy.controller.local import PongInputHandler, EventHandler
@@ -121,15 +123,14 @@ class PongTerminal(PongGame):
                     terminal.client.send(serialize(event))
                 return event
 
-            def handle_inputs(self, dt=None):
-                return super().handle_inputs(dt=None) # just handle input events, do not handle time elapsed
-            
-            def handle_events(self):
-                terminal._handle_ingoing_messages()
-                super().handle_events()
-            
-            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong): # type: ignore[override]
-                pong.override(status)
+            def on_time_elapsed(self, pong: Pong, dt: float, status: Pong = None): 
+                if not status:
+                    pong.update(dt)
+                else:
+                    pong.override(status)
+
+            def on_paddle_move(self, pong: Pong, paddle_index: Direction, direction: Direction):
+                pong.move_paddle(paddle_index, direction)
 
             def on_player_leave(self, pong: Pong, paddle_index: Direction):
                 terminal.stop()
@@ -137,7 +138,7 @@ class PongTerminal(PongGame):
         return Controller(terminal.pong, paddle_commands)
     
     def _handle_ingoing_messages(self):
-        if self.running:
+        while self.running:
             message = self.client.receive()
             message = deserialize(message)
             assert isinstance(message, pygame.event.Event), f"Expected {pygame.event.Event}, got {type(message)}"


### PR DESCRIPTION
To implement speculative execution, the client-side reception of messages from the server had to be made non-blocking. This was achieved by running the _handle_ingoing_messages function in a dedicated thread. As a result, the main thread no longer needs to manage message reception. Consequently, the override of the handle_events function was removed.

To enable client-side model updates in case of network issues, the event management logic was adjusted. Instead of relying solely on server responses to update the local model after sending user inputs, the client now updates its model independently based on its own inputs. The local model is then overwritten whenever a message is received from the server. Specifically, the client autonomously updates elements such as its paddle's movement and the passage of time. For this purpose, the on_paddle_move function was overridden, the handle_inputs method was modified to generate time_elapsed events, and the on_time_elapsed function was customized to trigger a full model overwrite only when the server produces time_elapsed events.

To execute and test this implementation:
To run the server:
`python -m dpongpy --mode centralised --role coordinator`
To run two clients:
`python -m dpongpy --mode centralised --role terminal --side left --keys wasd --host localhost
``python -m dpongpy --mode centralised --role terminal --side right --keys arrows --host localhost`